### PR TITLE
rest-client is a regular dependency, not dev-only

### DIFF
--- a/zapier_ruby.gemspec
+++ b/zapier_ruby.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rest-client"
+
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rest-client"
 end


### PR DESCRIPTION
Fixes #2, which hit me as well.
