### PR TITLE
accept an optional web hook id in ZapierRuby::Zapper#new, to support using zaps dynamically at runtime

### DIFF
--- a/lib/zapier_ruby/zapper.rb
+++ b/lib/zapier_ruby/zapper.rb
@@ -5,7 +5,7 @@ module ZapierRuby
     def initialize(zap_name, web_hook_id=nil)
       self.zap_name = zap_name
       self.logger = LoggerDecorator.new(config.enable_logging)
-      @zap_web_hook = web_hook_id if !web_hook_id.nil?
+      @zap_web_hook = web_hook_id if web_hook_id
     end
 
     def zap(params={})

--- a/lib/zapier_ruby/zapper.rb
+++ b/lib/zapier_ruby/zapper.rb
@@ -2,9 +2,10 @@ module ZapierRuby
   class Zapper
     attr_accessor :zap_name, :logger
 
-    def initialize(zap_name)
+    def initialize(zap_name, web_hook_id=nil)
       self.zap_name = zap_name
       self.logger = LoggerDecorator.new(config.enable_logging)
+      @zap_web_hook = web_hook_id if !web_hook_id.nil?
     end
 
     def zap(params={})


### PR DESCRIPTION
Super simple - I need to pull my zap IDs from a DB sometimes, hence this.  I'm happy to adjust the call style if you want to use an options hash or similar.
