### PR TITLE
support standard app

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ if zapper.zap({hello: "world"})
 else
  puts "it remains unzapped"
 end
+
+standard_url = 'https://hooks.zapier.com/hooks/standard/123456/xxxxxx/'
+zapper = ZapierRuby::ZapperHook.new(url: standard_url)
+
+if zapper.zap({hello: "world"})
+  puts "zapped it"
+else
+ puts "it remains unzapped"
+end
+
 ```
 
 You can find the value to fill in for "webhook id" in the location highlighted below ('xxxxxx' in the green box) when configuring your Zap:

--- a/lib/zapier_ruby.rb
+++ b/lib/zapier_ruby.rb
@@ -7,7 +7,9 @@ require 'zapier_ruby/version'
 require 'zapier_ruby/exceptions'
 require 'zapier_ruby/logger_decorator'
 require 'zapier_ruby/config'
+require 'zapier_ruby/base'
 require 'zapier_ruby/zapper'
+require 'zapier_ruby/zapper_hook'
 
 module ZapierRuby
   class << self
@@ -21,6 +23,6 @@ module ZapierRuby
 
   def self.configure_with(path_to_yaml_file)
     self.config ||= ZapierRuby::Config.new
-    config.configure_with(path_to_yaml_file)    
+    config.configure_with(path_to_yaml_file)
   end
 end

--- a/lib/zapier_ruby/base.rb
+++ b/lib/zapier_ruby/base.rb
@@ -1,0 +1,36 @@
+module ZapierRuby
+  class Base
+    attr_accessor :logger
+
+    private
+
+    def post_zap(params)
+      rest_client.post(params, zap_headers)
+    rescue RestClient::ExceptionWithResponse => err
+      raise ZapierServerError, err
+    end
+
+    def rest_client
+      @rest_client ||= RestClient::Resource.new(zap_url, ssl_version: 'TLSv1')
+    end
+
+    def zap_web_hook_id
+      @zap_web_hook ||= config.web_hooks[zap_name]
+    end
+
+    def zap_headers
+      {
+        "Accept" => " application/json",
+        "Content-Type" => "application/json"
+      }
+    end
+
+    def zap_url
+      "#{config.base_uri}#{zap_web_hook_id}/"
+    end
+
+    def config
+      ZapierRuby.config
+    end
+  end
+end

--- a/lib/zapier_ruby/zapper.rb
+++ b/lib/zapier_ruby/zapper.rb
@@ -1,6 +1,6 @@
 module ZapierRuby
-  class Zapper
-    attr_accessor :zap_name, :logger
+  class Zapper < Base
+    attr_accessor :zap_name
 
     def initialize(zap_name, web_hook_id=nil)
       self.zap_name = zap_name
@@ -15,38 +15,6 @@ module ZapierRuby
 
       logger.debug "Zapping #{zap_name} with params: #{params.to_s}"
       post_zap(params)
-    end
-
-    private
-
-    def post_zap(params)
-      rest_client.post(params, zap_headers)
-    rescue RestClient::ExceptionWithResponse => err
-      raise ZapierServerError, err
-    end
-
-    def rest_client
-      @rest_client ||= RestClient::Resource.new(zap_url, ssl_version: 'TLSv1')
-    end
-
-    def zap_web_hook_id
-      @zap_web_hook ||= config.web_hooks[zap_name]
-    end
-    private :zap_web_hook_id
-
-    def zap_headers
-      {
-        "Accept" => " application/json",
-        "Content-Type" => "application/json"
-      }
-    end
-
-    def zap_url
-      "#{config.base_uri}#{zap_web_hook_id}/"
-    end
-
-    def config
-      ZapierRuby.config
     end
   end
 end

--- a/lib/zapier_ruby/zapper_hook.rb
+++ b/lib/zapier_ruby/zapper_hook.rb
@@ -1,0 +1,21 @@
+module ZapierRuby
+  class ZapperHook < Base
+    attr_accessor :opt_hash
+
+    def initialize(opt_hash={})
+      self.opt_hash = opt_hash
+      self.logger = LoggerDecorator.new(config.enable_logging)
+    end
+
+    def zap(params={})
+      logger.debug "Zapping #{zap_url} with params: #{params.inspect}"
+      post_zap(params)
+    end
+
+    private
+
+    def zap_url
+      "#{opt_hash[:url]}"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'bundler/setup'
+require 'webmock/rspec'
 require 'pry'
 require 'zapier_ruby'
 

--- a/spec/zapier_ruby_spec.rb
+++ b/spec/zapier_ruby_spec.rb
@@ -1,14 +1,67 @@
 require 'spec_helper'
 
  describe 'ZapierRuby' do
-  let(:zapper) { ZapierRuby::Zapper }
-  let(:catch_url) { 'https://zapier.com/hooks/catch/webhook_id/' }
-
-  it '#zap_url' do
-    expect(zapper.new(:example_zap).send(:zap_url)).to eq catch_url
+  let(:body) { { message: 'Hey zapier' } }
+  let(:result) do
+    {
+      "status": "success",
+      "attempt": "5c304977-e06d-4580-86a3-xxxxxxxxxx",
+      "id": "096e7041-5510-4f5b-9597-xxxxxxxxxx",
+      "request_id": "5c304977-e06d-4580-86a3-xxxxxxxxxx"
+    }
   end
 
-   it '.base_uri' do
-    expect(ZapierRuby.config.base_uri).to eq "https://zapier.com/hooks/catch/"
+  describe 'Zapper' do
+    let(:zapper) { ZapierRuby::Zapper }
+    let(:catch_url) { 'https://zapier.com/hooks/catch/webhook_id/' }
+    let(:instance) { zapper.new(:example_zap) }
+
+    describe '#zap_url' do
+      it { expect(instance.send(:zap_url)).to eq catch_url }
+
+      it 'web_hook_id has val' do
+        url = zapper.new(:nil, 'webhook_id/uuiq').send(:zap_url)
+
+        expect(url).to eq 'https://zapier.com/hooks/catch/webhook_id/uuiq/'
+      end
+    end
+
+    it '.base_uri' do
+      expect(ZapierRuby.config.base_uri).to eq "https://zapier.com/hooks/catch/"
+    end
+
+    describe '#zap' do
+      it 'ZapierMisConfiguration'do
+        expect {
+          zapper.new(:typo_zap_name).zap
+        }.to raise_error(ZapierRuby::ZapierMisConfiguration)
+      end
+
+      it 'http require' do
+        stub_request(:post, catch_url).with(body: body).to_return(body: result.to_json)
+        response = instance.zap(body)
+
+        expect(response.code).to eq 200
+        expect(JSON.parse(response)['status']).to eq 'success'
+      end
+    end
+  end
+
+  describe 'ZapperHook' do
+    let(:zapper_hook) { ZapierRuby::ZapperHook }
+    let(:hookurl) { 'https://hooks.zapier.com/hooks/standard/1234/uuiq/' }
+    let(:instance) { zapper_hook.new(url: hookurl) }
+
+    it '#zap_url' do
+      expect(instance.send('zap_url')).to eq hookurl
+    end
+
+    it '#zap' do
+      stub_request(:post, hookurl).with(body: body).to_return(body: result.to_json)
+      response = instance.zap(body)
+
+      expect(response.code).to eq 200
+      expect(JSON.parse(response)['status']).to eq 'success'
+    end
   end
 end

--- a/zapier_ruby.gemspec
+++ b/zapier_ruby.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
Support  Zapier App repones hook URL.
https://github.com/zapier/zapier-platform-example-app-rest-hooks/blob/7af55121dc74676cfbd90bbef9dcaa6195777a39/triggers/recipe.js#L7

For example: `https://hooks.zapier.com/hooks/standard/123456/1833a4bc01934994b9734e6d97a19585/`
   